### PR TITLE
BUGFIX: Removed authMiddleware from StartApolloServer

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -25,10 +25,8 @@ const startApolloServer = async () => {
   app.use(express.urlencoded({ extended: false }));
   app.use(express.json());
 
-  app.use('/graphql', expressMiddleware(server, {
-    context: authMiddleware
-  }));
-  
+  app.use('/graphql', expressMiddleware(server));
+
   app.use(express.static(path.join(__dirname, '../client/dist')));
 
   app.get('*', (req, res) => {


### PR DESCRIPTION
This PR removes an unnecessary instance of authMiddleware executing in startApolloServer.